### PR TITLE
Gemfile: add rdoc, since after Ruby 3.5 it's not a bundled gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,5 @@ group :development do
   gem "bundler"
   gem "rake"
   gem "rake-compiler"
+  gem "rdoc"
 end


### PR DESCRIPTION
See #22 