### PR TITLE
Add macOS specific flags around file preallocation

### DIFF
--- a/ext/fcntl/fcntl.c
+++ b/ext/fcntl/fcntl.c
@@ -251,4 +251,50 @@ Init_fcntl(void)
      */
     rb_define_const(mFcntl, "F_DUP2FD_CLOEXEC", INT2NUM(F_DUP2FD_CLOEXEC));
 #endif
+
+#ifdef F_PREALLOCATE
+    /*
+     * macOS specific flag used for preallocating file space.
+     */
+    rb_define_const(mFcntl, "F_PREALLOCATE", INT2NUM(F_PREALLOCATE));
+#endif
+
+#ifdef F_ALLOCATECONTIG
+    /*
+     * macOS specific flag used with F_PREALLOCATE for allocating contiguous
+     * space.
+     */
+    rb_define_const(mFcntl, "F_ALLOCATECONTIG", INT2NUM(F_ALLOCATECONTIG));
+#endif
+
+#ifdef F_ALLOCATEALL
+    /*
+     * macOS specific flag used with F_PREALLOCATE for allocating all contiguous
+     * space or no space.
+     */
+    rb_define_const(mFcntl, "F_ALLOCATEALL", INT2NUM(F_ALLOCATEALL));
+#endif
+
+#ifdef F_ALLOCATEPERSIST
+    /*
+     * macOS specific flag used with F_PREALLOCATE. Allocate space that is not
+     * freed when close is called.
+     */
+    rb_define_const(mFcntl, "F_ALLOCATEPERSIST", INT2NUM(F_ALLOCATEPERSIST));
+#endif
+
+#ifdef F_PEOFPOSMODE
+    /*
+     * macOS specific flag used with F_PREALLOCATE. Allocate from the physical
+     * end of file
+     */
+    rb_define_const(mFcntl, "F_PEOFPOSMODE", INT2NUM(F_PEOFPOSMODE));
+#endif
+
+#ifdef F_VOLPOSMODE
+    /*
+     * macOS specific flag used with F_PREALLOCATE. Allocate from the volume offset.
+     */
+    rb_define_const(mFcntl, "F_VOLPOSMODE", INT2NUM(F_VOLPOSMODE));
+#endif
 }


### PR DESCRIPTION
I wanted to use file preallocation with fcntl, but the flags weren't available.  This commit just adds the missing flags.