### PR TITLE
Fix version comment on actions/checkout pin

### DIFF
--- a/.github/workflows/push_gem.yml
+++ b/.github/workflows/push_gem.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@d5126b9b3579e429dd52e51e68624dda2e05be25 # v1.267.0


### PR DESCRIPTION
ruby/fcntl#60 updated the pinned SHA in `push_gem.yml` to `3d3c42e5`, which is the `v7.0.1` tag of `actions/checkout`, but the trailing comment still said `v5.0.1`. This updates the comment to match the SHA.
